### PR TITLE
Update icalparser.py

### DIFF
--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -509,7 +509,7 @@ def parse_rrule(component, tz=UTC):
                     # Handle summer/winter time
                     rrules[index]["UNTIL"] = [
                         normalize(until, UTC)
-                        + tz.utcoffset(component["dtstart"].dt, is_dst=True)
+                        + tz.utcoffset(component["dtstart"].dt)
                         for until in rrules[index]["UNTIL"]
                     ]
 


### PR DESCRIPTION
The python standard library implementation of tzinfo doesn't take any keyword arguments to the utcoffset method. The pytz library has a separate implementation of utcoffset which takes an optional kw argument of is_dst. I've been encountering cases where the argument `is_dst=True` caused a `utc.utcoffset() got an unexpected keyword argument 'is_dst'` exception. 
I **believe** it can be safely deleted. 